### PR TITLE
Use 1ns for clock max offset

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -193,6 +193,7 @@ func (ts *TestServer) Start() error {
 	ts.mu.Unlock()
 
 	ts.cmd = exec.Command(ts.args[0], ts.args[1:]...)
+	ts.cmd.Env = []string{"COCKROACH_MAX_OFFSET=1ns"}
 
 	if len(ts.stdout) > 0 {
 		wr, err := newFileLogWriter(ts.stdout)


### PR DESCRIPTION
This prevents tests from getting the same time for the first 250ms of
operation, which is pretty confusing. Since this TestServer is a single
node, there's no point in the max offset being set to the default value.