### PR TITLE
Move the client lib to use the standard lib/pq

### DIFF
--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -21,7 +21,7 @@ package crdb
 import (
 	"database/sql"
 
-	"github.com/cockroachdb/pq"
+	"github.com/lib/pq"
 )
 
 // AmbiguousCommitError represents an error that left a transaction in an

--- a/crdb/tx_test.go
+++ b/crdb/tx_test.go
@@ -50,14 +50,17 @@ INSERT INTO d.t (acct, balance) VALUES (1, 100), (2, 100);
 		if err != nil {
 			return
 		}
-		for i, bal := range []*int{&bal1, &bal2} {
-			if !rows.Next() {
-				err = fmt.Errorf("expected two balances; got %d", i)
+		defer rows.Close()
+		balances := []*int{&bal1, &bal2}
+		i := 0
+		for ; rows.Next(); i += 1 {
+			if err = rows.Scan(balances[i]); err != nil {
 				return
 			}
-			if err = rows.Scan(bal); err != nil {
-				return
-			}
+		}
+		if i != 2 {
+			err = fmt.Errorf("expected two balances; got %d", i)
+			return
 		}
 		return
 	}


### PR DESCRIPTION
... instead of our forked one. This will help people who are trying to
link in both crdb and lib/pq.

The test fix was necessary because our forked libpq has a different way
of consuming results, making exhausting the `rows` cursor somehow not
necessary.

Fixes #17

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-go/18)
<!-- Reviewable:end -->
