### PR TITLE
testserver: use glibc binary on systems with eglibc

### DIFF
--- a/testserver/binaries.go
+++ b/testserver/binaries.go
@@ -38,7 +38,7 @@ func downloadFile(response *http.Response, filePath string) error {
 	return os.Chmod(filePath, finishedFileMode)
 }
 
-var glibcRE = regexp.MustCompile(`(?i)\bglibc\b`)
+var muslRE = regexp.MustCompile(`(?i)\bmusl\b`)
 
 func downloadLatestBinary() (string, error) {
 	goos := runtime.GOOS
@@ -50,10 +50,10 @@ func downloadLatestBinary() (string, error) {
 			out, err := cmd.Output()
 			if err != nil {
 				log.Printf("%s: out=%q err=%s", cmd.Args, out, err)
-			} else if glibcRE.Match(out) {
-				return "-gnu"
+			} else if muslRE.Match(out) {
+				return "-musl"
 			}
-			return "-musl"
+			return "-gnu"
 		}()
 	}
 	binaryName := fmt.Sprintf("cockroach.%s-%s", goos, runtime.GOARCH)


### PR DESCRIPTION
Some versions of Ubuntu use eglibc ("embedded glibc") instead of glibc,
so they don't match the glibc regex.  Attempting to run the musl
binaries on these systems hangs forever. (We should probably look into
this separately; the musl binaries should work on these systems.) For
now, though, work around the issue by grepping for the less-common
"musl" rather than "glibc."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/cockroach-go/31)
<!-- Reviewable:end -->
