### PR TITLE
Add ExecuteInTx

### DIFF
--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -60,8 +60,10 @@ type Tx interface {
 }
 
 // ExecuteInTx runs fn inside tx which should already have begun.
-// *** WARNING ***: tx should not have been used before being passed to ExecuteInTx; any
-// statements executed prior may be rolled back even though tx may commit successfully.
+// WARNING: Do not execute any statements on the supplied tx before calling this function.
+// ExecuteInTx will only retry statements that are performed within the supplied
+// closure (fn). Any statements performed on the tx before ExecuteInTx is invoked will *not*
+// be re-run if the transaction needs to be retried.
 func ExecuteInTx(tx Tx, fn func() error) (err error) {
 	defer func() {
 		if err == nil {

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -60,7 +60,7 @@ type Tx interface {
 }
 
 // ExecuteInTx runs fn inside tx which should already have begun.
-// WARNING: Do not execute any statements on the supplied tx before calling this function.
+// *WARNING*: Do not execute any statements on the supplied tx before calling this function.
 // ExecuteInTx will only retry statements that are performed within the supplied
 // closure (fn). Any statements performed on the tx before ExecuteInTx is invoked will *not*
 // be re-run if the transaction needs to be retried.

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -60,6 +60,8 @@ type Tx interface {
 }
 
 // ExecuteInTx runs fn inside tx which should already have begun.
+// *** WARNING ***: tx should not have been used before being passed to ExecuteInTx; any
+// statements executed prior may be rolled back even though tx may commit successfully.
 func ExecuteInTx(tx Tx, fn func() error) (err error) {
 	defer func() {
 		if err == nil {

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -50,7 +50,7 @@ func ExecuteTx(db *sql.DB, fn func(*sql.Tx) error) (err error) {
 	if err != nil {
 		return err
 	}
-	return ExecuteBegunTx(tx, func() error { return fn(tx) })
+	return ExecuteInTx(tx, func() error { return fn(tx) })
 }
 
 type Tx interface {
@@ -59,8 +59,8 @@ type Tx interface {
 	Rollback() error
 }
 
-// ExecuteBegunTx runs fn inside tx which should already have begun.
-func ExecuteBegunTx(tx Tx, fn func() error) (err error) {
+// ExecuteInTx runs fn inside tx which should already have begun.
+func ExecuteInTx(tx Tx, fn func() error) (err error) {
 	defer func() {
 		if err == nil {
 			// Ignore commit errors. The tx has already been committed by RELEASE.

--- a/crdb/tx_test.go
+++ b/crdb/tx_test.go
@@ -30,7 +30,7 @@ func TestExecuteTx(t *testing.T) {
 	testExecuteTxInner(t, executeTx)
 }
 
-func TestExecuteBegunTx(t *testing.T) {
+func TestExecuteInTx(t *testing.T) {
 	executeTx := func(db *sql.DB, fn func(tx *sql.Tx) error) (err error) {
 		tx, err := db.Begin()
 		if err != nil {

--- a/crdb/tx_test.go
+++ b/crdb/tx_test.go
@@ -36,7 +36,7 @@ func TestExecuteBegunTx(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return ExecuteBegunTx(tx, func() error { return fn(tx) })
+		return ExecuteInTx(tx, func() error { return fn(tx) })
 	}
 	testExecuteTxInner(t, executeTx)
 }


### PR DESCRIPTION
Add support for executing cockroach transactions using [GORM](https://github.com/jinzhu/gorm).

Refactor retry logic into internal function which uses an internal 
`transaction` interface.
