### PR TITLE
Add support for context

### DIFF
--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -17,6 +17,7 @@
 package crdb
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -42,19 +43,18 @@ type AmbiguousCommitError struct {
 //
 // NOTE: the supplied exec closure should not have external side
 // effects beyond changes to the database.
-func ExecuteTx(db *sql.DB, fn func(*sql.Tx) error) (err error) {
+func ExecuteTx(ctx context.Context, db *sql.DB, txopts *sql.TxOptions, fn func(*sql.Tx) error) error {
 	// Start a transaction.
-	var tx *sql.Tx
-	tx, err = db.Begin()
+	tx, err := db.BeginTx(ctx, txopts)
 	if err != nil {
 		return err
 	}
-	return ExecuteInTx(tx, func() error { return fn(tx) })
+	return ExecuteInTx(ctx, tx, func() error { return fn(tx) })
 }
 
 // Tx is used to permit clients to implement custom transaction logic.
 type Tx interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	Commit() error
 	Rollback() error
 }
@@ -64,7 +64,7 @@ type Tx interface {
 // ExecuteInTx will only retry statements that are performed within the supplied
 // closure (fn). Any statements performed on the tx before ExecuteInTx is invoked will *not*
 // be re-run if the transaction needs to be retried.
-func ExecuteInTx(tx Tx, fn func() error) (err error) {
+func ExecuteInTx(ctx context.Context, tx Tx, fn func() error) (err error) {
 	defer func() {
 		if err == nil {
 			// Ignore commit errors. The tx has already been committed by RELEASE.
@@ -77,7 +77,7 @@ func ExecuteInTx(tx Tx, fn func() error) (err error) {
 	}()
 	// Specify that we intend to retry this txn in case of CockroachDB retryable
 	// errors.
-	if _, err = tx.Exec("SAVEPOINT cockroach_restart"); err != nil {
+	if _, err = tx.ExecContext(ctx, "SAVEPOINT cockroach_restart"); err != nil {
 		return err
 	}
 
@@ -88,7 +88,7 @@ func ExecuteInTx(tx Tx, fn func() error) (err error) {
 			// RELEASE acts like COMMIT in CockroachDB. We use it since it gives us an
 			// opportunity to react to retryable errors, whereas tx.Commit() doesn't.
 			released = true
-			if _, err = tx.Exec("RELEASE SAVEPOINT cockroach_restart"); err == nil {
+			if _, err = tx.ExecContext(ctx, "RELEASE SAVEPOINT cockroach_restart"); err == nil {
 				return nil
 			}
 		}
@@ -103,7 +103,7 @@ func ExecuteInTx(tx Tx, fn func() error) (err error) {
 			}
 			return err
 		}
-		if _, err = tx.Exec("ROLLBACK TO SAVEPOINT cockroach_restart"); err != nil {
+		if _, err = tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT cockroach_restart"); err != nil {
 			// ROLLBACK TO SAVEPOINT failed. If it failed with a lib/pq error, we want
 			// to pass this error to the client, but also include the original error
 			// message and code. So, we'll do some surgery on lib/pq errors in


### PR DESCRIPTION
Clients may want to use sql package context
functionality, for example, to trace all sql
queries.