### PR TITLE
support pgx errors

### DIFF
--- a/crdb/README.md
+++ b/crdb/README.md
@@ -1,0 +1,9 @@
+CRDB
+====
+
+`crdb` is a wrapper around the logic for issuing SQL transactions which performs
+retries (as required by CockroachDB).
+
+Note that unfortunately there is no generic way of extracting a pg error code;
+the library has to recognize driver-dependent error types. We currently support
+`github.com/lib/pq` and `github.com/jackc/pgx`.


### PR DESCRIPTION
 This change adds code to recognize `pgx` errors as well. Note that
unlike `lib/pq`, merely importing `pgx` doesn't register a `sql`
driver (that's done by `pgx/stdlib`).

Fixes #48.