### PR TITLE
add variant of ExecuteTx that runs on a specific sql.Conn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
 - 1.x
-- 1.8.x
+- 1.10.x
 
 script:
   - go test -p 1       -v ./...

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -76,6 +76,18 @@ func ExecuteTx(
 	return ExecuteInTx(ctx, tx, func() error { return fn(tx) })
 }
 
+// ExecuteTxOnConn is a variant of ExecuteTx that is run on a specific sql.Conn.
+func ExecuteTxOnConn(
+	ctx context.Context, conn *sql.Conn, txopts *sql.TxOptions, fn func(*sql.Tx) error,
+) error {
+	// Start a transaction.
+	tx, err := conn.BeginTx(ctx, txopts)
+	if err != nil {
+		return err
+	}
+	return ExecuteInTx(ctx, tx, func() error { return fn(tx) })
+}
+
 // Tx is used to permit clients to implement custom transaction logic.
 type Tx interface {
 	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)


### PR DESCRIPTION
I considered making an interface for `BeginTx` so you can pass either `*sql.DB` or `*sql.Conn` but it ended up being more hassle documenting what's going on.