### PR TITLE
Use *pgconn.PgError instead of pgx.PgError

### DIFF
--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgconn"
 	"github.com/lib/pq"
 )
 
@@ -143,7 +143,7 @@ func errCode(err error) string {
 	case *pq.Error:
 		return string(t.Code)
 
-	case pgx.PgError:
+	case *pgconn.PgError:
 		return t.Code
 
 	default:

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/jackc/pgx/pgconn"
+	"github.com/jackc/pgconn"
 	"github.com/lib/pq"
 )
 


### PR DESCRIPTION
`pgx.PgError` does not exist any more.