### PR TITLE
switch to pgx v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
 - 1.x
-- 1.8.x
+- 1.13.x
 
 script:
   - go test -p 1       -v ./...

--- a/crdb/README.md
+++ b/crdb/README.md
@@ -6,4 +6,5 @@ retries (as required by CockroachDB).
 
 Note that unfortunately there is no generic way of extracting a pg error code;
 the library has to recognize driver-dependent error types. We currently support
-`github.com/lib/pq` and `github.com/jackc/pgx`.
+`github.com/lib/pq` and `github.com/jackc/pgconn` (which is used by
+`github.com/jackc/pgx/v4`; previous pgx versions are not supported).

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/jackc/pgx"
+	"github.com/jackc/pgconn"
 	"github.com/lib/pq"
 )
 
@@ -143,7 +143,7 @@ func errCode(err error) string {
 	case *pq.Error:
 		return string(t.Code)
 
-	case pgx.PgError:
+	case *pgconn.PgError:
 		return t.Code
 
 	default:


### PR DESCRIPTION
A new version of pgx was release which no longer has a pgx.Error.
Instead, there's a new pgconn library with the errors. This commit
switches cockroach-go to work with this new library and drops support
for old pgx versions.

Fixes #54
Touches jackc/pgconn#15