### PR TITLE
add support for pgx and gorm 

### DIFF
--- a/crdb/common.go
+++ b/crdb/common.go
@@ -1,0 +1,80 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crdb
+
+import (
+	"context"
+)
+
+// Tx abstracts the operations needed by ExecuteInTx so that different
+// frameworks (e.g. go's sql package, pgx, gorm) can be used with ExecuteInTx.
+type Tx interface {
+	Exec(context.Context, string, ...interface{}) error
+	Commit(context.Context) error
+	Rollback(context.Context) error
+}
+
+// ExecuteInTx runs fn inside tx. This method is primarily intended for internal
+// use. See other packages for higher-level, framework-specific ExecuteTx()
+// functions.
+//
+// *WARNING*: It is assumed that no statements have been executed on the
+// supplied Tx. ExecuteInTx will only retry statements that are performed within
+// the supplied closure (fn). Any statements performed on the tx before
+// ExecuteInTx is invoked will *not* be re-run if the transaction needs to be
+// retried.
+//
+// fn is subject to the same restrictions as the fn passed to ExecuteTx.
+func ExecuteInTx(ctx context.Context, tx Tx, fn func() error) (err error) {
+	defer func() {
+		if err == nil {
+			// Ignore commit errors. The tx has already been committed by RELEASE.
+			_ = tx.Commit(ctx)
+		} else {
+			// We always need to execute a Rollback() so sql.DB releases the
+			// connection.
+			_ = tx.Rollback(ctx)
+		}
+	}()
+	// Specify that we intend to retry this txn in case of CockroachDB retryable
+	// errors.
+	if err = tx.Exec(ctx, "SAVEPOINT cockroach_restart"); err != nil {
+		return err
+	}
+
+	for {
+		released := false
+		err = fn()
+		if err == nil {
+			// RELEASE acts like COMMIT in CockroachDB. We use it since it gives us an
+			// opportunity to react to retryable errors, whereas tx.Commit() doesn't.
+			released = true
+			if err = tx.Exec(ctx, "RELEASE SAVEPOINT cockroach_restart"); err == nil {
+				return nil
+			}
+		}
+		// We got an error; let's see if it's a retryable one and, if so, restart.
+		if !errIsRetryable(err) {
+			if released {
+				err = newAmbiguousCommitError(err)
+			}
+			return err
+		}
+
+		if retryErr := tx.Exec(ctx, "ROLLBACK TO SAVEPOINT cockroach_restart"); retryErr != nil {
+			return newTxnRestartError(retryErr, err)
+		}
+	}
+}

--- a/crdb/crdbgorm/gorm.go
+++ b/crdb/crdbgorm/gorm.go
@@ -1,0 +1,59 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crdbgorm
+
+import (
+	"context"
+	"database/sql"
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/jinzhu/gorm"
+)
+
+// ExecuteTx runs fn inside a transaction and retries it as needed. On
+// non-retryable failures, the transaction is aborted and rolled back; on
+// success, the transaction is committed.
+//
+// See crdb.ExecuteTx() for more information.
+func ExecuteTx(
+	ctx context.Context, db *gorm.DB, opts *sql.TxOptions, fn func(tx *gorm.DB) error,
+) error {
+	tx := db.BeginTx(ctx, opts)
+	if db.Error != nil {
+		return db.Error
+	}
+	return crdb.ExecuteInTx(ctx, gormTxAdapter{tx}, func() error { return fn(tx) })
+}
+
+// gormTxAdapter adapts a *gorm.DB to a crdb.Tx.
+type gormTxAdapter struct {
+	db *gorm.DB
+}
+
+var _ crdb.Tx = gormTxAdapter{}
+
+// Exec is part of the crdb.Tx interface.
+func (tx gormTxAdapter) Exec(_ context.Context, q string, args ...interface{}) error {
+	return tx.db.Exec(q, args...).Error
+}
+
+// Commit is part of the crdb.Tx interface.
+func (tx gormTxAdapter) Commit(_ context.Context) error {
+	return tx.db.Commit().Error
+}
+
+// Rollback is part of the crdb.Tx interface.
+func (tx gormTxAdapter) Rollback(_ context.Context) error {
+	return tx.db.Rollback().Error
+}

--- a/crdb/crdbgorm/gorm_test.go
+++ b/crdb/crdbgorm/gorm_test.go
@@ -1,0 +1,107 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crdbgorm
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/cockroachdb/cockroach-go/testserver"
+	"github.com/jinzhu/gorm"
+	"testing"
+)
+
+// TestExecuteTx verifies transaction retry using the classic example of write
+// skew in bank account balance transfers.
+func TestExecuteTx(t *testing.T) {
+	ts, err := testserver.NewTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ts.Start(); err != nil {
+		t.Fatal(err)
+	}
+	url := ts.PGURL()
+	db, err := sql.Open("postgres", url.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ts.WaitForInit(db); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	gormDB, err := gorm.Open("postgres", ts.PGURL().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Set to true and gorm logs all the queries.
+	gormDB.LogMode(false)
+
+	if err := crdb.ExecuteTxGenericTest(ctx, gormWriteSkewTest{db: gormDB}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Account is our model, which corresponds to the "accounts" database
+// table.
+type Account struct {
+	ID      int `gorm:"primary_key"`
+	Balance int
+}
+
+type gormWriteSkewTest struct {
+	db *gorm.DB
+}
+
+var _ crdb.WriteSkewTest = gormWriteSkewTest{}
+
+func (t gormWriteSkewTest) Init(context.Context) error {
+	t.db.AutoMigrate(&Account{})
+	t.db.Create(&Account{ID: 1, Balance: 100})
+	t.db.Create(&Account{ID: 2, Balance: 100})
+	return t.db.Error
+}
+
+// ExecuteTx is part of the crdb.WriteSkewTest interface.
+func (t gormWriteSkewTest) ExecuteTx(ctx context.Context, fn func(tx interface{}) error) error {
+	return ExecuteTx(ctx, t.db, nil /* opts */, func(tx *gorm.DB) error {
+		return fn(tx)
+	})
+}
+
+// GetBalances is part of the crdb.WriteSkewTest interface.
+func (t gormWriteSkewTest) GetBalances(_ context.Context, txi interface{}) (int, int, error) {
+	tx := txi.(*gorm.DB)
+
+	var accounts []Account
+	tx.Find(&accounts)
+	if len(accounts) != 2 {
+		return 0, 0, fmt.Errorf("expected two balances; got %d", len(accounts))
+	}
+	return accounts[0].Balance, accounts[1].Balance, nil
+}
+
+// UpdateBalance is part of the crdb.WriteSkewInterface.
+func (t gormWriteSkewTest) UpdateBalance(
+	_ context.Context, txi interface{}, accountID, delta int,
+) error {
+	tx := txi.(*gorm.DB)
+	var acc Account
+	tx.First(&acc, accountID)
+	acc.Balance += delta
+	return tx.Save(acc).Error
+}

--- a/crdb/crdbpgx/pgx.go
+++ b/crdb/crdbpgx/pgx.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crdbpgx
+
+import (
+	"context"
+	"github.com/cockroachdb/cockroach-go/crdb"
+
+	"github.com/jackc/pgx"
+)
+
+// ExecuteTx runs fn inside a transaction and retries it as needed. On
+// non-retryable failures, the transaction is aborted and rolled back; on
+// success, the transaction is committed.
+//
+// See crdb.ExecuteTx() for more information.
+//
+// conn can be a pgx.Conn or a pgxpool.Pool.
+func ExecuteTx(
+	ctx context.Context, conn Conn, txOptions pgx.TxOptions, fn func(pgx.Tx) error,
+) error {
+	tx, err := conn.BeginTx(ctx, txOptions)
+	if err != nil {
+		return err
+	}
+	return crdb.ExecuteInTx(ctx, pgxTxAdapter{tx}, func() error { return fn(tx) })
+}
+
+// Conn abstracts pgx transactions creators: pgx.Conn and pgxpool.Pool.
+type Conn interface {
+	Begin(context.Context) (pgx.Tx, error)
+	BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error)
+}
+
+type pgxTxAdapter struct {
+	tx pgx.Tx
+}
+
+var _ crdb.Tx = pgxTxAdapter{}
+
+func (tx pgxTxAdapter) Commit(ctx context.Context) error {
+	return tx.tx.Commit(ctx)
+}
+
+func (tx pgxTxAdapter) Rollback(ctx context.Context) error {
+	return tx.tx.Rollback(ctx)
+}
+
+// Exec is part of the crdb.Tx interface.
+func (tx pgxTxAdapter) Exec(ctx context.Context, q string, args ...interface{}) error {
+	_, err := tx.tx.Exec(ctx, q, args...)
+	return err
+}

--- a/crdb/testing_util.go
+++ b/crdb/testing_util.go
@@ -1,0 +1,131 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package crdb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// WriteSkewTest abstracts the operations that needs to be performed by a
+// particular framework for the purposes of TestExecuteTx. This allows the test
+// to be written once and run for any framework supported by this library.
+type WriteSkewTest interface {
+	Init(context.Context) error
+	ExecuteTx(ctx context.Context, fn func(tx interface{}) error) error
+	GetBalances(ctx context.Context, tx interface{}) (bal1, bal2 int, err error)
+	UpdateBalance(ctx context.Context, tx interface{}, acct, delta int) error
+}
+
+// ExecuteTxGenericTest represents the structure of a test for the ExecuteTx
+// function. The actual database operations are abstracted by framework; the
+// idea is that tests for different frameworks implement that interface and then
+// invoke this test.
+//
+// The test interleaves two transactions such that one of them will require a
+// restart because of write skew.
+func ExecuteTxGenericTest(ctx context.Context, framework WriteSkewTest) error {
+	framework.Init(ctx)
+	// wg is used as a barrier, blocking each transaction after it performs the
+	// initial read until they both read.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	runTxn := func(iter *int) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			*iter = 0
+			errCh <- framework.ExecuteTx(ctx, func(tx interface{}) (retErr error) {
+				defer func() {
+					if retErr == nil {
+						return
+					}
+					// Wrap the error so that we test the library's unwrapping.
+					retErr = testError{cause: retErr}
+				}()
+
+				*iter++
+				bal1, bal2, err := framework.GetBalances(ctx, tx)
+				if err != nil {
+					return err
+				}
+				// If this is the first iteration, wait for the other tx to also read.
+				if *iter == 1 {
+					wg.Done()
+					wg.Wait()
+				}
+				// Now, subtract from one account and give to the other.
+				if bal1 > bal2 {
+					if err := framework.UpdateBalance(ctx, tx, 1, -100); err != nil {
+						return err
+					}
+					if err := framework.UpdateBalance(ctx, tx, 2, +100); err != nil {
+						return err
+					}
+				} else {
+					if err := framework.UpdateBalance(ctx, tx, 1, +100); err != nil {
+						return err
+					}
+					if err := framework.UpdateBalance(ctx, tx, 2, -100); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+		}()
+		return errCh
+	}
+
+	var iters1, iters2 int
+	txn1Err := runTxn(&iters1)
+	txn2Err := runTxn(&iters2)
+	if err := <-txn1Err; err != nil {
+		return fmt.Errorf("expected success in txn1; got %s", err)
+	}
+	if err := <-txn2Err; err != nil {
+		return fmt.Errorf("expected success in txn2; got %s", err)
+	}
+	if iters1+iters2 <= 2 {
+		return fmt.Errorf("expected at least one retry between the competing transactions; "+
+			"got txn1=%d, txn2=%d", iters1, iters2)
+	}
+
+	var bal1, bal2 int
+	err := framework.ExecuteTx(ctx, func(txi interface{}) error {
+		var err error
+		bal1, bal2, err = framework.GetBalances(ctx, txi)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if bal1 != 100 || bal2 != 100 {
+		return fmt.Errorf("expected balances to be restored without error; "+
+			"got acct1=%d, acct2=%d: %s", bal1, bal2, err)
+	}
+	return nil
+}
+
+type testError struct {
+	cause error
+}
+
+func (t testError) Error() string {
+	return "test error"
+}
+
+func (t testError) Unwrap() error {
+	return t.cause
+}

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Execute runs fn and retries it as needed. It is used to add retry handling to
-// the execution of a single statement or single batch of statements. If a
-// multi-statement transaction is being run, use ExecuteTx instead.
+// the execution of a single statement. If a multi-statement transaction is
+// being run, use ExecuteTx instead.
 //
 // Retry handling for individual statements (implicit transactions) is usually
 // performed automatically on the CockroachDB SQL gateway. As such, use of this


### PR DESCRIPTION
Before this patch, the library only had support for Go's sql package.
This patch adds subpackages for pgx and gorm, providing suitable
ExecuteTx() functions. We had a function called ExecuteInTx which was
intended to be used with transactions initiated by other frameworks.
However the function's abstraction of a Txn did not match any framework,
and the API was generally dangerous because it simply assumed that the
respective txn had not previously been used to run statements.
In contrast, the new ExecuteTx() functions work with the respective
frameworks and controls the creation of the transaction.

This patch also makes the crdb package not import a pgx package any
more.

Fixes #60