### PR TITLE
update readme note about pgx v4 not being supported

### DIFF
--- a/crdb/README.md
+++ b/crdb/README.md
@@ -6,8 +6,11 @@ retries (as required by CockroachDB).
 
 Note that unfortunately there is no generic way of extracting a pg error code;
 the library has to recognize driver-dependent error types. We currently support
-`github.com/lib/pq` and `github.com/jackc/pgconn` (which is used by
-`github.com/jackc/pgx/v4`; previous pgx versions are not supported).
+[`github.com/lib/pq`](https://github.com/lib/pq), and
+[`github.com/jackc/pgx`](https://github.com/jackc/pgx) when used in database/sql
+driver mode.
+
+Subpackages provide support for gorm, and pgx used in standalone-library mode. 
 
 Note for developers: if you make any changes here (especially if they modify public
 APIs), please verify that the code in https://github.com/cockroachdb/examples-go 

--- a/crdb/crdbpgx/README.md
+++ b/crdb/crdbpgx/README.md
@@ -1,0 +1,7 @@
+`crdbpgx` is a wrapper around the logic for issuing SQL transactions which
+performs retries (as required by CockroachDB) when using
+[`github.com/jackc/pgx`](https://github.com/jackc/pgx) in standalone-library
+mode. pgx versions below v4 are not supported.
+
+If you're using pgx just as a driver for the standard `database/sql` package,
+use the parent `crdb` package instead.


### PR DESCRIPTION
It used to be until recently that the crdb package only supported pgx
v4. Now crdb supports v3 too, but the new crdbpgx package only supports
v4 for other reasons.