### PR TITLE
Add function to fully create and start a test server

### DIFF
--- a/crdb/crdbgorm/gorm_test.go
+++ b/crdb/crdbgorm/gorm_test.go
@@ -16,7 +16,6 @@ package crdbgorm
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach-go/v2/testserver"
@@ -29,17 +28,6 @@ import (
 func TestExecuteTx(t *testing.T) {
 	ts, err := testserver.NewTestServer()
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ts.Start(); err != nil {
-		t.Fatal(err)
-	}
-	url := ts.PGURL()
-	db, err := sql.Open("postgres", url.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ts.WaitForInit(db); err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()

--- a/crdb/crdbpgx/pgx_test.go
+++ b/crdb/crdbpgx/pgx_test.go
@@ -16,7 +16,6 @@ package crdbpgx
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach-go/v2/testserver"
@@ -30,17 +29,6 @@ import (
 func TestExecuteTx(t *testing.T) {
 	ts, err := testserver.NewTestServer()
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ts.Start(); err != nil {
-		t.Fatal(err)
-	}
-	url := ts.PGURL()
-	db, err := sql.Open("postgres", url.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := ts.WaitForInit(db); err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()

--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -35,9 +35,6 @@ func TestPGURLWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := ts.Start(); err != nil {
-		t.Fatal(err)
-	}
 	url := ts.PGURL().String()
 	if trimmed := strings.TrimSpace(url); url != trimmed {
 		t.Errorf("unexpected whitespace in server URL: %q", url)


### PR DESCRIPTION
Implement `StartTestServer` function that allows user to get fully started and ready to use `TestServer`. 
Here is the use case: I want a test server up and running with a single function call, the same way as it's done via function `NewDBForTest` that returns `sql.DB`. I can't use the existing function, because I connect to the database via different client e.g. `pgx`  and `TestServer` has .`PGURL()` that I can utilise. 