### PR TITLE
testserver: run cockroach with Pdeathsig on linux

### DIFF
--- a/testserver/exec_linux.go
+++ b/testserver/exec_linux.go
@@ -1,0 +1,30 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build linux
+
+package testserver
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// execCommand attaches the Pdeathsig to tear down the cockroach cluster if the
+// parent process dies.
+func execCommand(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+	return cmd
+}

--- a/testserver/exec_not_linux.go
+++ b/testserver/exec_not_linux.go
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !linux
+
+package testserver
+
+import "os/exec"
+
+func execCommand(name string, args ...string) *exec.Cmd {
+	return exec.Command(name, args...)
+}

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -62,10 +62,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach-go/v2/testserver/version"
 	// Import postgres driver.
 	_ "github.com/lib/pq"
-
-	"github.com/cockroachdb/cockroach-go/v2/testserver/version"
 )
 
 var customBinaryFlag = flag.String("cockroach-binary", "", "Use specified cockroach binary")
@@ -438,7 +437,7 @@ func (ts *testServerImpl) Start() error {
 	ts.state = stateRunning
 	ts.mu.Unlock()
 
-	ts.cmd = exec.Command(ts.cmdArgs[0], ts.cmdArgs[1:]...)
+	ts.cmd = execCommand(ts.cmdArgs[0], ts.cmdArgs[1:]...)
 	ts.cmd.Env = []string{"COCKROACH_MAX_OFFSET=1ns"}
 
 	if len(ts.stdout) > 0 {


### PR DESCRIPTION
If the test crashes for whatever reason and does not run the deferred
cleanup, then we would like very much for the operating system to kill
the subprocess. Linux has nice support for this.