### PR TITLE
Remove PGURL nil check from testserver docs

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -29,13 +29,7 @@
 //      }
 //      defer ts.Stop()
 //
-//      url := ts.PGURL()
-//      if url == nil {
-//        t.Fatalf("url not found")
-//      }
-//      t.Logf("URL: %s", url.String())
-//
-//      db, err := sql.Open("postgres", url.String())
+//      db, err := sql.Open("postgres", ts.PGURL().String())
 //      if err != nil {
 //        t.Fatal(err)
 //      }


### PR DESCRIPTION
NewTestServer performs the check so it is redundant.