### PR TITLE
support downloading the latest stable version of CRDB

### DIFF
--- a/testserver/binaries.go
+++ b/testserver/binaries.go
@@ -15,9 +15,15 @@
 package testserver
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"mime"
 	"net/http"
@@ -28,6 +34,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -39,56 +46,23 @@ const (
 	writingFileMode  = 0600 // Allow reads so that another process can check if there's a flock.
 )
 
-func downloadFile(response *http.Response, filePath string, tc *TestConfig) error {
-	output, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, writingFileMode)
-	if err != nil {
-		return fmt.Errorf("error creating %s: %w", filePath, err)
-	}
-	defer func() { _ = output.Close() }()
+const (
+	linuxUrlpat  = "https://binaries.cockroachdb.com/cockroach-v%s.linux-amd64.tgz"
+	macUrlpat    = "https://binaries.cockroachdb.com/cockroach-v%s.darwin-10.9-amd64.tgz"
+	winUrlpat    = "https://binaries.cockroachdb.com/cockroach-v%s.windows-6.2-amd64.zip"
+	sourceUrlPat = "https://binaries.cockroachdb.com/cockroach-v%s.src.tgz)"
+)
 
-	log.Printf("saving %s to %s, this may take some time", response.Request.URL, filePath)
-
-	// Assign a flock to the local file.
-	// If the downloading process is killed in the middle,
-	// the lock will be automatically dropped.
-	localFileLock := flock.New(filePath)
-
-	if _, err := localFileLock.TryLock(); err != nil {
-		return err
-	}
-
-	defer func() { _ = localFileLock.Unlock() }()
-
-	if tc.IsTest && tc.StopDownloadInMiddle {
-		log.Printf("download process killed")
-		output.Close()
-		return errStoppedInMiddle
-	}
-
-	if _, err := io.Copy(output, response.Body); err != nil {
-		return fmt.Errorf("problem saving %s to %s: %w", response.Request.URL, filePath, err)
-	}
-
-	// Download was successful, add the rw bits.
-	if err := output.Chmod(finishedFileMode); err != nil {
-		return err
-	}
-
-	if err := localFileLock.Unlock(); err != nil {
-		return err
-	}
-
-	// We explicitly close here to ensure the error is checked; the deferred
-	// close above will likely error in this case, but that's harmless.
-	return output.Close()
-}
+// updatesUrl is used to get the info of the latest stable version of CRDB.
+// Note that it may return a withdrawn version, but the risk is low for local tests here.
+const updatesUrl = "https://register.cockroachdb.com/api/updates"
 
 var muslRE = regexp.MustCompile(`(?i)\bmusl\b`)
 
 // GetDownloadResponse return the http response of a CRDB download.
 // It creates the url for downloading a CRDB binary for current runtime OS,
 // makes a request to this url, and return the response.
-func GetDownloadResponse() (*http.Response, error) {
+func GetDownloadResponse(nonStable bool) (*http.Response, string, error) {
 	goos := runtime.GOOS
 	if goos == "linux" {
 		goos += func() string {
@@ -108,49 +82,57 @@ func GetDownloadResponse() (*http.Response, error) {
 	if runtime.GOOS == "windows" {
 		binaryName += ".exe"
 	}
-	url := &url.URL{
-		Scheme: "https",
-		Host:   "edge-binaries.cockroachdb.com",
-		Path:   path.Join("cockroach", fmt.Sprintf("%s.%s", binaryName, latestSuffix)),
+
+	var dbUrl string
+	var err error
+
+	latestStableVersion := ""
+	// For the latest (beta) CRDB, we use the `edge-binaries.cockroachdb.com` host.
+	if nonStable {
+		u := &url.URL{
+			Scheme: "https",
+			Host:   "edge-binaries.cockroachdb.com",
+			Path:   path.Join("cockroach", fmt.Sprintf("%s.%s", binaryName, latestSuffix)),
+		}
+		dbUrl = u.String()
+	} else {
+		// For the latest stable CRDB, we use the url provided in the CRDB release page.
+		dbUrl, latestStableVersion, err = getLatestStableVersionInfo()
+		if err != nil {
+			return nil, "", err
+		}
 	}
-	log.Printf("GET %s", url)
-	response, err := http.Get(url.String())
+
+	log.Printf("GET %s", dbUrl)
+	response, err := http.Get(dbUrl)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	if response.StatusCode != 200 {
-		return nil, fmt.Errorf("error downloading %s: %d (%s)", url,
+		return nil, "", fmt.Errorf("error downloading %s: %d (%s)", dbUrl,
 			response.StatusCode, response.Status)
 	}
-	return response, nil
+	return response, latestStableVersion, nil
 }
 
-func GetDownloadFilename(response *http.Response) (string, error) {
-	const contentDisposition = "Content-Disposition"
-	_, disposition, err := mime.ParseMediaType(response.Header.Get(contentDisposition))
-	if err != nil {
-		return "", fmt.Errorf("error parsing %s headers %s: %s", contentDisposition, response.Header, err)
-	}
-
-	filename, ok := disposition["filename"]
-	if !ok {
-		return "", fmt.Errorf("content disposition header %s did not contain filename", disposition)
-	}
-	return filename, nil
-}
-
-func downloadLatestBinary(tc *TestConfig) (string, error) {
-	response, err := GetDownloadResponse()
+// downloadBinary saves the latest version of CRDB into a local binary file,
+// and returns the path for this local binary.
+// To download the latest STABLE version of CRDB, set `nonStable` to false.
+// To download the bleeding edge version of CRDB, set `nonStable` to true.
+func downloadBinary(tc *TestConfig, nonStable bool) (string, error) {
+	response, latestStableVersion, err := GetDownloadResponse(nonStable)
 	if err != nil {
 		return "", err
 	}
+
 	defer func() { _ = response.Body.Close() }()
 
-	filename, err := GetDownloadFilename(response)
+	filename, err := GetDownloadFilename(response, nonStable, latestStableVersion)
 	if err != nil {
 		return "", err
 	}
+
 	localFile := filepath.Join(os.TempDir(), filename)
 	for {
 		info, err := os.Stat(localFile)
@@ -188,15 +170,224 @@ func downloadLatestBinary(tc *TestConfig) (string, error) {
 		time.Sleep(time.Millisecond * 10)
 	}
 
-	err = downloadFile(response, localFile, tc)
+	output, err := os.OpenFile(localFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, writingFileMode)
 	if err != nil {
+		return "", fmt.Errorf("error creating %s: %w", localFile, err)
+	}
+
+	// Assign a flock to the local file.
+	// If the downloading process is killed in the middle,
+	// the lock will be automatically dropped.
+	localFileLock := flock.New(localFile)
+
+	if _, err := localFileLock.TryLock(); err != nil {
+		return "", err
+	}
+
+	defer func() { _ = localFileLock.Unlock() }()
+
+	if tc.IsTest && tc.StopDownloadInMiddle {
+		log.Printf("download process killed")
+		output.Close()
+		return "", errStoppedInMiddle
+	}
+
+	var downloadMethod func(*http.Response, *os.File, string) error
+
+	if nonStable {
+		downloadMethod = downloadBinaryFromResponse
+	} else {
+		if runtime.GOOS == "windows" {
+			downloadMethod = downloadBinaryFromZip
+		} else {
+			downloadMethod = downloadBinaryFromTar
+		}
+	}
+	log.Printf("saving %s to %s, this may take some time", response.Request.URL, localFile)
+	if err := downloadMethod(response, output, localFile); err != nil {
 		if !errors.Is(err, errStoppedInMiddle) {
 			if err := os.Remove(localFile); err != nil {
-				log.Printf("failed to remove %s: %v", localFile, err)
+				log.Printf("failed to remove %s: %s", localFile, err)
 			}
 		}
 		return "", err
 	}
 
+	if err := localFileLock.Unlock(); err != nil {
+		return "", err
+	}
+
+	if err := output.Close(); err != nil {
+		return "", err
+	}
+
 	return localFile, nil
+}
+
+// GetDownloadFilename returns the local filename of the downloaded CRDB binary file.
+func GetDownloadFilename(
+	response *http.Response, nonStableDB bool, latestStableVersion string,
+) (string, error) {
+	if nonStableDB {
+		const contentDisposition = "Content-Disposition"
+		_, disposition, err := mime.ParseMediaType(response.Header.Get(contentDisposition))
+		if err != nil {
+			return "", fmt.Errorf("error parsing %s headers %s: %w", contentDisposition, response.Header, err)
+		}
+		filename, ok := disposition["filename"]
+		if !ok {
+			return "", fmt.Errorf("content disposition header %s did not contain filename", disposition)
+		}
+		return filename, nil
+	}
+	filename := fmt.Sprintf("cockroach-%s", latestStableVersion)
+	if runtime.GOOS == "windows" {
+		filename += ".exe"
+	}
+	return filename, nil
+}
+
+// getLatestStableVersionInfo returns the latest stable CRDB's download URL,
+// and the formatted corresponding version number. The download URL is based
+// on the runtime OS.
+// Note that it may return a withdrawn version, but the risk is low for local tests here.
+func getLatestStableVersionInfo() (string, string, error) {
+	resp, err := http.Get(updatesUrl)
+	if err != nil {
+		return "", "", err
+	}
+	var respJson map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&respJson); err != nil {
+		return "", "", err
+	}
+	latestStableVersion, ok := respJson["version"]
+	if !ok {
+		return "", "", fmt.Errorf("api/updates response is of wrong format")
+	}
+	var downloadUrl string
+	switch runtime.GOOS {
+	case "linux":
+		downloadUrl = fmt.Sprintf(linuxUrlpat, latestStableVersion)
+	case "darwin":
+		downloadUrl = fmt.Sprintf(macUrlpat, latestStableVersion)
+	case "windows":
+		downloadUrl = fmt.Sprintf(winUrlpat, latestStableVersion)
+	}
+	latestStableVerFormatted := strings.ReplaceAll(latestStableVersion, ".", "-")
+	return downloadUrl, latestStableVerFormatted, nil
+}
+
+// downloadBinaryFromResponse copies the http response's body directly into a local binary.
+func downloadBinaryFromResponse(response *http.Response, output *os.File, filePath string) error {
+	if _, err := io.Copy(output, response.Body); err != nil {
+		return fmt.Errorf("problem saving %s to %s: %w", response.Request.URL, filePath, err)
+	}
+
+	// Download was successful, add the rw bits.
+	if err := output.Chmod(finishedFileMode); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// downloadBinaryFromTar writes the binary compressed in a tar from a http response
+// to a local file.
+// It is created because the download url from the release page only provides the tar.gz/zip
+// for a pre-compiled binary.
+func downloadBinaryFromTar(response *http.Response, output *os.File, filePath string) error {
+	// Unzip the tar file from the response's body.
+	gzf, err := gzip.NewReader(response.Body)
+	if err != nil {
+		return fmt.Errorf("cannot read tar from response body: %w", err)
+	}
+	// Read the files from the tar.
+	tarReader := tar.NewReader(gzf)
+	for {
+		header, err := tarReader.Next()
+
+		// No more file from tar to read.
+		if err == io.EOF {
+			return fmt.Errorf("cannot find the binary from tar")
+		}
+
+		if err != nil {
+			return fmt.Errorf("cannot untar: %w", err)
+		}
+
+		// Only copy the cockroach binary.
+		// The header.Name is of the form "zip_name/file_name".
+		// We extract the file name.
+		splitHeaderName := strings.Split(header.Name, "/")
+		fileName := splitHeaderName[len(splitHeaderName)-1]
+		if fileName == "cockroach" {
+			// Copy the binary to desired path.
+			if _, err := io.Copy(output, tarReader); err != nil {
+				return fmt.Errorf(
+					"problem saving %s to %s: %w",
+					response.Request.URL, filePath,
+					err,
+				)
+			}
+			if err := output.Chmod(finishedFileMode); err != nil {
+				return err
+			}
+			return nil
+		}
+
+	}
+	return nil
+}
+
+// downloadBinaryFromZip writes the binary compressed in a zip from a http response
+// to a local file.
+// It is created because the download url from the release page only provides the tar.gz/zip
+// for a pre-compiled binary.
+func downloadBinaryFromZip(response *http.Response, output *os.File, filePath string) error {
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return fmt.Errorf("cannot read zip from response body: %w", err)
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	findFile := false
+	// Read all the files from zip archive.
+	for _, zipFile := range zipReader.File {
+		splitHeaderName := strings.Split(zipFile.Name, "/")
+		fileName := splitHeaderName[len(splitHeaderName)-1]
+		fmt.Printf("filename=%s", fileName)
+		if fileName == "cockroach" {
+			findFile = true
+			if err := readZipFile(zipFile, output); err != nil {
+				return fmt.Errorf("problem saving %s to %s: %w",
+					response.Request.URL,
+					filePath,
+					err)
+			}
+			if err := output.Chmod(finishedFileMode); err != nil {
+				return err
+			}
+		}
+	}
+	if !findFile {
+		return fmt.Errorf("cannot find the binary from zip")
+	}
+
+	return nil
+}
+
+func readZipFile(zf *zip.File, target *os.File) error {
+	f, err := zf.Open()
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err = io.Copy(target, f); err != nil {
+		return err
+	}
+	return nil
 }

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -190,6 +190,7 @@ type testServerArgs struct {
 	storeOnDisk  bool    // to save database in disk
 	storeMemSize float64 // the proportion of available memory allocated to test server
 	testConfig   TestConfig
+	nonStableDB  bool
 }
 
 // SecureOpt is a TestServer option that can be passed to NewTestServer to
@@ -227,6 +228,14 @@ func SetStoreMemSizeOpt(memSize float64) TestServerOpt {
 func RootPasswordOpt(pw string) TestServerOpt {
 	return func(args *testServerArgs) {
 		args.rootPW = pw
+	}
+}
+
+// NonStableDbOpt is a TestServer option that can be passed to NewTestServer to
+// download the latest beta version of CRDB, but not necessary a stable one.
+func NonStableDbOpt() TestServerOpt {
+	return func(args *testServerArgs) {
+		args.nonStableDB = true
 	}
 }
 
@@ -272,7 +281,7 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 	if cockroachBinary != "" {
 		log.Printf("Using custom cockroach binary: %s", cockroachBinary)
 	} else {
-		cockroachBinary, err = downloadLatestBinary(&serverArgs.testConfig)
+		cockroachBinary, err = downloadBinary(&serverArgs.testConfig, serverArgs.nonStableDB)
 		if err != nil {
 			if errors.Is(err, errStoppedInMiddle) {
 				// If the testserver is intentionally killed in the middle of downloading,


### PR DESCRIPTION
resolves #83

This commit sets the default mode for database downloads
to "Download the latest stable version of CRDB".

We get the latest stable version through
https://register.cockroachdb.com/api/updates, and
save it to a local file with `cockroach-majorv-minorv-patch`
naming pattern in the `tmp` directory. The downloading is
OS-specific.

**Problem unsolved**: the tenant tests with proxy always fail
with stable CRDB, but pass with latest non-stable CRDB.