### PR TITLE
README,crdb: update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CockroachDB Go Helpers
+# CockroachDB Go Helpers  [![Go Reference](https://pkg.go.dev/badge/github.com/cockroachdb/cockroach-go/v2/crdb.svg)](https://pkg.go.dev/github.com/cockroachdb/cockroach-go/v2/crdb)
 
 This project contains helpers for CockroachDB users writing in Go:
 - `crdb` and its subpackages provide wrapper functions for retrying transactions that fail

--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -67,7 +67,7 @@ import (
 // Instead, add context by returning an error that implements either:
 // - a `Cause() error` method, in the manner of github.com/pkg/errors, or
 // - an `Unwrap() error` method, in the manner of the Go 1.13 standard
-//   library.
+// library.
 //
 // To achieve this, you can implement your own error type, or use
 // `errors.Wrap()` from github.com/pkg/errors or
@@ -134,7 +134,7 @@ func Execute(fn func() error) (err error) {
 // Instead, add context by returning an error that implements either:
 // - a `Cause() error` method, in the manner of github.com/pkg/errors, or
 // - an `Unwrap() error` method, in the manner of the Go 1.13 standard
-//   library.
+// library.
 //
 // To achieve this, you can implement your own error type, or use
 // `errors.Wrap()` from github.com/pkg/errors or


### PR DESCRIPTION
Add a link to the pkg.go.dev documentation in the README. Also, fix the
formatting on a couple comments. The indentation of 'library' caused
godoc/pkg.go.dev to present the line as a code block.