### PR TITLE
rollback on panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cockroachdb/cockroach-go/v2
 go 1.13
 
 require (
-	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/gofrs/flock v0.8.1
 	github.com/jackc/pgx/v4 v4.10.1
 	github.com/jmoiron/sqlx v1.3.1
 	github.com/lib/pq v1.10.0


### PR DESCRIPTION
Fixes #76 

~I tried to do the minimum amount of changes to fix the issue.~
UPDATE: did a very small amount of clean up to help me understand a bit better.

There are currently no tests around this. I explored the current tests, and after a while (lots of abstraction), I was able to understand them for the most part. However, it seems that currently (and please correct me if I'm wrong) there are no existing tests actually testing the existing `defer` statement? I would have expected at least some testing of a "non-retryable" error resulting in a rollback, but either there are not any or I couldn't find them.

If someone could advise me on what tests for rollback (whether or not via `panic` or "non-retryable" error, probably should add tests for both) should look like, I'd much appreciate it and am happy to work on them.

Let me know if you have questions, thank you! 🙏 