### PR TITLE
Don't use placeholder for username

### DIFF
--- a/testserver/tenant.go
+++ b/testserver/tenant.go
@@ -188,6 +188,7 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 
 	tenant := &testServerImpl{
 		serverArgs: ts.serverArgs,
+		version:    ts.version,
 		state:      stateNew,
 		baseDir:    ts.baseDir,
 		cmdArgs:    args,
@@ -230,7 +231,7 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 
 	if rootPassword != "" {
 		// Allow root to login via password.
-		if _, err := tenantDB.Exec(`ALTER USER $1 WITH PASSWORD $2`, "root", rootPassword); err != nil {
+		if _, err := tenantDB.Exec(`ALTER USER root WITH PASSWORD $1`, rootPassword); err != nil {
 			return nil, fmt.Errorf("%s cannot set password: %w", tenantserverMessagePrefix, err)
 		}
 

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -103,6 +103,7 @@ type TestServer interface {
 // testServerImpl is a TestServer implementation.
 type testServerImpl struct {
 	mu         sync.RWMutex
+	version    *version.Version
 	serverArgs testServerArgs
 	state      int
 	baseDir    string
@@ -393,6 +394,7 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 
 	ts := &testServerImpl{
 		serverArgs:       *serverArgs,
+		version:          v,
 		state:            stateNew,
 		baseDir:          baseDir,
 		cmdArgs:          args,
@@ -492,7 +494,7 @@ func (ts *testServerImpl) pollListeningURLFile() error {
 			return err
 		}
 		defer db.Close()
-		if _, err := db.Exec(`ALTER USER $1 WITH PASSWORD $2`, "root", pw); err != nil {
+		if _, err := db.Exec(`ALTER USER root WITH PASSWORD $1`, pw); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This is needed in order to work with v22.1 (unreleased).

This also includes a small change to keep the version number as a field
on testserver.