### PR TITLE
Make max retry error show correct message

### DIFF
--- a/crdb/error.go
+++ b/crdb/error.go
@@ -71,6 +71,9 @@ func newMaxRetriesExceededError(err error, maxRetries int) *MaxRetriesExceededEr
 	}
 }
 
+// Error implements the error interface.
+func (e *MaxRetriesExceededError) Error() string { return e.msg }
+
 // TxnRestartError represents an error when restarting a transaction. `cause` is
 // the error from restarting the txn and `retryCause` is the original error which
 // triggered the restart.

--- a/crdb/error_test.go
+++ b/crdb/error_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package crdb
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMaxRetriesExceededError(t *testing.T) {
+	origError := fmt.Errorf("root error")
+	err := newMaxRetriesExceededError(origError, 10)
+	if !strings.HasPrefix(err.Error(), "retrying txn failed after 10 attempts.") {
+		t.Fatalf("expected txn retry error message")
+	}
+	if !errors.Is(err, origError) {
+		t.Fatal("expected to find root error cause")
+	}
+}


### PR DESCRIPTION
Previously, it would just show the original cause of the retries, not
the message that says it is giving up on retrying.