### PR TITLE
fix: user errors.As for error type assertion

### DIFF
--- a/crdb/error.go
+++ b/crdb/error.go
@@ -16,23 +16,6 @@ package crdb
 
 import "fmt"
 
-// errorCause returns the original cause of the error, if possible. An
-// error has a proximate cause if it's type is compatible with Go's
-// errors.Unwrap() or pkg/errors' Cause(); the original cause is the
-// end of the causal chain.
-func errorCause(err error) error {
-	for err != nil {
-		if c, ok := err.(interface{ Cause() error }); ok {
-			err = c.Cause()
-		} else if c, ok := err.(interface{ Unwrap() error }); ok {
-			err = c.Unwrap()
-		} else {
-			break
-		}
-	}
-	return err
-}
-
 type txError struct {
 	cause error
 }


### PR DESCRIPTION
Use proper error unstacking with Go's std libraries. The current code will only check for the first level of nesting whereas Go's std libraries are able to unpack several layers of wrapping.