### PR TITLE
feat: expose testserver BaseDir

### DIFF
--- a/crdb/tx.go
+++ b/crdb/tx.go
@@ -102,7 +102,7 @@ func Execute(fn func() error) (err error) {
 	}
 }
 
-type txConfigKey struct {}
+type txConfigKey struct{}
 
 // WithMaxRetries configures context so that ExecuteTx retries tx specified
 // number of times when encountering retryable errors.

--- a/crdb/tx_test.go
+++ b/crdb/tx_test.go
@@ -42,8 +42,8 @@ func TestConfigureRetries(t *testing.T) {
 	if numRetriesFromContext(ctx) != defaultRetries {
 		t.Fatal("expect default number of retries")
 	}
-	ctx = WithMaxRetries(context.Background(), 123 + defaultRetries)
-	if numRetriesFromContext(ctx) != defaultRetries + 123 {
+	ctx = WithMaxRetries(context.Background(), 123+defaultRetries)
+	if numRetriesFromContext(ctx) != defaultRetries+123 {
 		t.Fatal("expected default+123 retires")
 	}
 }

--- a/testserver/tenant.go
+++ b/testserver/tenant.go
@@ -80,11 +80,11 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 		if ts.version.AtLeast(version.MustParse("v22.1.0-alpha")) {
 			certArgs = append(certArgs, "127.0.0.1", "[::1]", "localhost", "*.local")
 		}
-		certArgs = append(certArgs, secureFlag, "--ca-key=" + filepath.Join(certsDir, "ca.key"))
-        createCertCmd := exec.Command(cockroachBinary, certArgs...)
+		certArgs = append(certArgs, secureFlag, "--ca-key="+filepath.Join(certsDir, "ca.key"))
+		createCertCmd := exec.Command(cockroachBinary, certArgs...)
 		log.Printf("%s executing: %s", tenantserverMessagePrefix, createCertCmd)
 		if err := createCertCmd.Run(); err != nil {
-            return nil, fmt.Errorf("%s command %s failed: %w", tenantserverMessagePrefix, createCertCmd, err)
+			return nil, fmt.Errorf("%s command %s failed: %w", tenantserverMessagePrefix, createCertCmd, err)
 		}
 	}
 	// Create a new tenant.

--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -99,6 +99,8 @@ type TestServer interface {
 	// WaitForInit retries until a SQL connection is successfully established to
 	// this server.
 	WaitForInit() error
+	// BaseDir returns directory StoreOnDiskOpt writes to if used.
+	BaseDir() string
 }
 
 // testServerImpl is a TestServer implementation.
@@ -438,6 +440,11 @@ func (ts *testServerImpl) Stdout() string {
 // Stderr returns the entire contents of the process' stderr.
 func (ts *testServerImpl) Stderr() string {
 	return ts.stderrBuf.String()
+}
+
+// BaseDir returns directory StoreOnDiskOpt writes to if used.
+func (ts *testServerImpl) BaseDir() string {
+	return ts.baseDir
 }
 
 // PGURL returns the postgres connection URL to reach the started


### PR DESCRIPTION
This PR adds `BaseDir() string` which exposes CRDB's root directory which helps us to, for example, load back ups when starting the database.

Please excuse the formatting noise, it is caused by `go fmt -w -s .`