### PR TITLE
Check tx error rather than db error in ExecuteTx

### DIFF
--- a/crdb/crdbgorm/gorm.go
+++ b/crdb/crdbgorm/gorm.go
@@ -31,8 +31,8 @@ func ExecuteTx(
 	ctx context.Context, db *gorm.DB, opts *sql.TxOptions, fn func(tx *gorm.DB) error,
 ) error {
 	tx := db.WithContext(ctx).Begin(opts)
-	if db.Error != nil {
-		return db.Error
+	if tx.Error != nil {
+		return tx.Error
 	}
 	return crdb.ExecuteInTx(ctx, gormTxAdapter{tx}, func() error { return fn(tx) })
 }


### PR DESCRIPTION
In ExecuteTx, a transaction (tx) is begun but the error check only looks for errors in the original db object. If the transaction fails to start, the error is not caught immediately.