### PR TITLE
Define CockroachBinaryPath option for testserver.

### DIFF
--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -188,6 +188,17 @@ func TestRunServer(t *testing.T) {
 	}
 }
 
+func TestCockroachBinaryPathOpt(t *testing.T) {
+	_, err := testserver.NewTestServer(testserver.CockroachBinaryPathOpt("doesnotexist"))
+	if err == nil {
+		t.Fatal("expected err, got nil")
+	}
+	wantSubstring := "command doesnotexist version failed"
+	if msg := err.Error(); !strings.Contains(msg, wantSubstring) {
+		t.Fatalf("error message %q does not contain %q", msg, wantSubstring)
+	}
+}
+
 func TestPGURLWhitespace(t *testing.T) {
 	ts, err := testserver.NewTestServer()
 	if err != nil {


### PR DESCRIPTION
CockroachBinaryPath is a TestServer option that can be passed to NewTestServer
to specify the path of the cockroach binary. This can be used to avoid
downloading cockroach if running tests in an environment with no internet
connection, for instance.