### PR TITLE
set cmd.Dir to stop directory pollution

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -555,6 +555,11 @@ func (ts *testServerImpl) Start() error {
 		"COCKROACH_TRUST_CLIENT_PROVIDED_SQL_REMOTE_ADDR=true",
 	}
 
+	// Set the working directory of the cockroach process to our temp folder.
+	// This stops cockroach from polluting the project directory with _dump
+	// folders.
+	ts.cmd.Dir = ts.baseDir
+
 	if len(ts.stdout) > 0 {
 		wr, err := newFileLogWriter(ts.stdout)
 		if err != nil {


### PR DESCRIPTION
    Previously, invocations of TestServer would results in various _dump
    directories being created by the cockroachdb process. While these
    directories were empty, it was bothersome to see them created and
    show up in file exporers. This commit sets cmd.Dir to a temporary
    directory to avoid polluting the project directory of consumers.