### PR TITLE
Update crdb binary path to absolute

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -304,6 +304,11 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 	var err error
 	if serverArgs.cockroachBinary != "" {
 		log.Printf("Using custom cockroach binary: %s", serverArgs.cockroachBinary)
+		cockroachBinary, err := filepath.Abs(serverArgs.cockroachBinary)
+		if err == nil {
+			// Update path to absolute.
+			serverArgs.cockroachBinary = cockroachBinary
+		}
 	} else {
 		serverArgs.cockroachBinary, err = downloadBinary(&serverArgs.testConfig, serverArgs.nonStableDB)
 		if err != nil {

--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -189,11 +189,18 @@ func TestRunServer(t *testing.T) {
 }
 
 func TestCockroachBinaryPathOpt(t *testing.T) {
-	_, err := testserver.NewTestServer(testserver.CockroachBinaryPathOpt("doesnotexist"))
+	crdbBinary := "doesnotexist"
+	_, err := testserver.NewTestServer(testserver.CockroachBinaryPathOpt(crdbBinary))
 	if err == nil {
 		t.Fatal("expected err, got nil")
 	}
-	wantSubstring := "command doesnotexist version failed"
+	// Confirm that the command is updated to reference the absolute path
+	// of the custom cockroachdb binary.
+	cmdPath, fPathErr := filepath.Abs(crdbBinary)
+	if fPathErr != nil {
+		cmdPath = crdbBinary
+	}
+	wantSubstring := fmt.Sprintf("command %s version failed", cmdPath)
 	if msg := err.Error(); !strings.Contains(msg, wantSubstring) {
 		t.Fatalf("error message %q does not contain %q", msg, wantSubstring)
 	}


### PR DESCRIPTION
The teamcity build for cockroachdb repo uses
a relative path for setting a custom cockroach
binary. This change resolves the relative path
to an absolute path. This way updating the command's
base directory does not impact the cockroach binary
look up while running example-orm tests.