### PR TITLE
Add External IO Dir TestServerOpt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/lib/pq v1.10.6
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
 	golang.org/x/sys v0.0.0-20220513210249-45d2b4557a2a // indirect
 	gorm.io/driver/postgres v1.3.5


### PR DESCRIPTION
This PR adds `ExternalIODirOpt` in order to let users specify the `--external-io-dir` startup option. This will let users test how their application functions in backup and restore operations without having to use an on-disk testserver.

I also noticed that while `require` was used in `testserver_test.go`, it was not imported in `go.mod`, so I added it in.