### PR TITLE
Make testserver multi-node more robust.

### DIFF
--- a/testserver/testservernode.go
+++ b/testserver/testservernode.go
@@ -25,7 +25,6 @@ func (ts *testServerImpl) StopNode(nodeNum int) error {
 	ts.mu.Lock()
 	ts.nodes[nodeNum].state = stateStopped
 	ts.mu.Unlock()
-	ts.pgURL[nodeNum].u = nil
 	cmd := ts.nodes[nodeNum].startCmd
 
 	// Kill the process.


### PR DESCRIPTION
- Fix race condition in pollListeningURLFile.
- Add Opts for init node timeout and poll listening url.
  - InitTimeoutOpt, PollListenURLTimeoutOpt
- Parallelize restart test