### PR TITLE
Use separate stdout/stderr for each node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        # The latest crlfmt requires go1.19.
         go install github.com/cockroachdb/crlfmt@024b567ce87bf2b89f2cffabb7a8f4ea0cfa8b98
         go install github.com/kisielk/errcheck@latest
         go install github.com/mdempsky/unconvert@latest

--- a/testserver/binaries.go
+++ b/testserver/binaries.go
@@ -232,9 +232,6 @@ func downloadBinary(tc *TestConfig, desiredVersion string, nonStable bool) (stri
 func GetDownloadFilename(
 	response *http.Response, nonStableDB bool, desiredVersion string,
 ) (string, error) {
-	if nonStableDB {
-		log.Printf("Obsolete usage of GetDownloadFilename() with `nonStable` set to `true`")
-	}
 	filename := fmt.Sprintf("cockroach-%s", desiredVersion)
 	if runtime.GOOS == "windows" {
 		filename += ".exe"

--- a/testserver/tenant.go
+++ b/testserver/tenant.go
@@ -235,6 +235,8 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 			// TODO(asubiotto): Specify listeningURLFile once we support dynamic
 			//  ports.
 			listeningURLFile: "",
+			stdout:           filepath.Join(ts.baseDir, logsDirName, fmt.Sprintf("cockroach.tenant.%d.stdout", tenantID)),
+			stderr:           filepath.Join(ts.baseDir, logsDirName, fmt.Sprintf("cockroach.tenant.%d.stderr", tenantID)),
 		},
 	}
 
@@ -243,8 +245,6 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 		version:     ts.version,
 		serverState: stateNew,
 		baseDir:     ts.baseDir,
-		stdout:      filepath.Join(ts.baseDir, logsDirName, fmt.Sprintf("cockroach.tenant.%d.stdout", tenantID)),
-		stderr:      filepath.Join(ts.baseDir, logsDirName, fmt.Sprintf("cockroach.tenant.%d.stderr", tenantID)),
 		nodes:       nodes,
 	}
 

--- a/testserver/testservernode.go
+++ b/testserver/testservernode.go
@@ -55,23 +55,23 @@ func (ts *testServerImpl) StartNode(i int) error {
 	// folders.
 	currCmd.Dir = ts.baseDir
 
-	if len(ts.stdout) > 0 {
-		wr, err := newFileLogWriter(ts.stdout)
+	if len(ts.nodes[i].stdout) > 0 {
+		wr, err := newFileLogWriter(ts.nodes[i].stdout)
 		if err != nil {
-			return fmt.Errorf("unable to open file %s: %w", ts.stdout, err)
+			return fmt.Errorf("unable to open file %s: %w", ts.nodes[i].stdout, err)
 		}
-		ts.stdoutBuf = wr
+		ts.nodes[i].stdoutBuf = wr
 	}
-	currCmd.Stdout = ts.stdoutBuf
+	currCmd.Stdout = ts.nodes[i].stdoutBuf
 
-	if len(ts.stderr) > 0 {
-		wr, err := newFileLogWriter(ts.stderr)
+	if len(ts.nodes[i].stderr) > 0 {
+		wr, err := newFileLogWriter(ts.nodes[i].stderr)
 		if err != nil {
-			return fmt.Errorf("unable to open file %s: %w", ts.stderr, err)
+			return fmt.Errorf("unable to open file %s: %w", ts.nodes[1].stderr, err)
 		}
-		ts.stderrBuf = wr
+		ts.nodes[i].stderrBuf = wr
 	}
-	currCmd.Stderr = ts.stderrBuf
+	currCmd.Stderr = ts.nodes[i].stderrBuf
 
 	for k, v := range defaultEnv() {
 		currCmd.Env = append(currCmd.Env, k+"="+v)

--- a/testserver/testservernode.go
+++ b/testserver/testservernode.go
@@ -29,7 +29,12 @@ func (ts *testServerImpl) StopNode(nodeNum int) error {
 
 	// Kill the process.
 	if cmd.Process != nil {
-		return cmd.Process.Kill()
+		if err := cmd.Process.Kill(); err != nil {
+			return err
+		}
+		if _, err := cmd.Process.Wait(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This also changes the per-node store directories so they are all inside
the base directory.