### PR TITLE
Do not use redirects for latest binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
         go:
           - "1.17"
           - "1.18"
+          - "1.19"
     steps:
     - uses: actions/checkout@v2
 
@@ -25,7 +26,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        go install github.com/cockroachdb/crlfmt@latest
+        go install github.com/cockroachdb/crlfmt@024b567ce87bf2b89f2cffabb7a8f4ea0cfa8b98
         go install github.com/kisielk/errcheck@latest
         go install github.com/mdempsky/unconvert@latest
         go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .#*
 *.test
 testserver/cockroach-data/
+testserver/temp_binaries/

--- a/testserver/binaries.go
+++ b/testserver/binaries.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -234,16 +233,7 @@ func GetDownloadFilename(
 	response *http.Response, nonStableDB bool, desiredVersion string,
 ) (string, error) {
 	if nonStableDB {
-		const contentDisposition = "Content-Disposition"
-		_, disposition, err := mime.ParseMediaType(response.Header.Get(contentDisposition))
-		if err != nil {
-			return "", fmt.Errorf("error parsing %s headers %s: %w", contentDisposition, response.Header, err)
-		}
-		filename, ok := disposition["filename"]
-		if !ok {
-			return "", fmt.Errorf("content disposition header %s did not contain filename", disposition)
-		}
-		return filename, nil
+		log.Printf("Obsolete usage of GetDownloadFilename() with `nonStable` set to `true`")
 	}
 	filename := fmt.Sprintf("cockroach-%s", desiredVersion)
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
After we moved the edge CDN to GCS-backed Google CDN, the latest binaries became actual binaries, without redirects, as it was before.

This PR removes the redirect resolution logic.

I also pinned clrfmt to the version that doesn't use generics and added go-1.19 to the test matrix.