### PR TITLE
Support custom host on listen address

### DIFF
--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -50,6 +50,12 @@ func TestRunServer(t *testing.T) {
 			instantiation: func(t *testing.T) (*sql.DB, func()) { return testserver.NewDBForTest(t) },
 		},
 		{
+			name: "InsecureWithHostOverride",
+			instantiation: func(t *testing.T) (*sql.DB, func()) {
+				return testserver.NewDBForTest(t, testserver.ListenAddrHostOpt("0.0.0.0"))
+			},
+		},
+		{
 			name: "InsecureWithCustomizedMemSize",
 			instantiation: func(t *testing.T) (*sql.DB, func()) {
 				return testserver.NewDBForTest(t, testserver.SetStoreMemSizeOpt(0.3))


### PR DESCRIPTION
Previously, the testserver could only listen on localhost. This meant that there was no way to spin up an instance of the testserver on one machine and access it from another. This commit adds support for custom hosts so that the testserver can be accessed from outside hosts if needed.

For my use case, I need this so that I can have a docker-compose file with two services: one for the testserver and one for my go tests. For the networking to work out, I need to be able to listen on `0.0.0.0` not `localhost`.