### PR TITLE
testserver: respect the TMPDIR environment variable

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -455,12 +455,9 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 		}
 	}
 
-	// Force "/tmp/" so avoid OSX's really long temp directory names
-	// which get us over the socket filename length limit.
-	baseDir, err := os.MkdirTemp("/tmp", "cockroach-testserver")
+	baseDir, err := os.MkdirTemp("", "cockroach-testserver")
 	if err != nil {
-		return nil, fmt.Errorf("%s: could not create temp directory: %w",
-			testserverMessagePrefix, err)
+		return nil, fmt.Errorf("%s: could not create temp directory: %w", testserverMessagePrefix, err)
 	}
 
 	mkDir := func(name string) (string, error) {


### PR DESCRIPTION
This will be useful for cockroachdb CI, which has logic that can preserve temporary files in TMPDIR in the CI artifacts.

It's safe to remove the logic to use "/tmp" since that was initially added in a2ed1c60, but it's no longer needed since the testserver no longer creates UNIX sockets.