### PR TITLE
Allow non-hardcoded ports for multinode cluster

### DIFF
--- a/testserver/tenant.go
+++ b/testserver/tenant.go
@@ -254,6 +254,7 @@ func (ts *testServerImpl) NewTenantServer(proxy bool) (TestServer, error) {
 	tenantURL := ts.pgURL[0].orig
 	tenantURL.Host = sqlAddr
 	tenant.pgURL = make([]pgURLChan, 1)
+	tenant.pgURL[0].started = make(chan struct{})
 	tenant.pgURL[0].set = make(chan struct{})
 
 	tenant.setPGURL(&tenantURL)

--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -630,9 +630,6 @@ func TestUpgradeNode(t *testing.T) {
 		testserver.CockroachBinaryPathOpt(absPathOldBinary),
 		testserver.UpgradeCockroachBinaryPathOpt(absPathNewBinary),
 		testserver.StoreOnDiskOpt(),
-		testserver.AddListenAddrPortOpt(26257),
-		testserver.AddListenAddrPortOpt(26258),
-		testserver.AddListenAddrPortOpt(26259),
 	)
 	require.NoError(t, err)
 	defer ts.Stop()
@@ -700,14 +697,13 @@ func TestUpgradeNode(t *testing.T) {
 	}
 }
 
-var wg = sync.WaitGroup{}
-
 // testFlockWithDownloadPassing is to test the flock over downloaded CRDB binary with
 // two goroutines, the second goroutine waits for the first goroutine to
 // finish downloading the CRDB binary into a local file.
 func testFlockWithDownloadPassing(
 	t *testing.T, opts ...testserver.TestServerOpt,
 ) (*sql.DB, func()) {
+	var wg = sync.WaitGroup{}
 
 	localFile, err := getLocalFile(false)
 	if err != nil {


### PR DESCRIPTION
This required the join and init args to be computed on the fly, since we can no longer infer them until after a node has started.

informs https://github.com/cockroachdb/cockroach/issues/98549
informs https://github.com/cockroachdb/cockroach/issues/98612
informs https://github.com/cockroachdb/cockroach/issues/98594