### PR TITLE
testserver: pass `logtostderr` when starting multiple nodes

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -577,6 +577,7 @@ func NewTestServer(opts ...TestServerOpt) (TestServer, error) {
 			nodes[i].startCmdArgs = []string{
 				serverArgs.cockroachBinary,
 				startCmd,
+				"--logtostderr",
 				secureOpt,
 				storeArg,
 				fmt.Sprintf(


### PR DESCRIPTION
This commit adds the `--logtostderr` command line flag when starting a cluster with multiple nodes, making the behavior consistent with single-node clusters. In addition, this makes the change introduced in 68fede3 more useful, as the stderr will include the actual cockroach logs.