### PR TITLE
testserver: expose `NoFileCleanup` option to allow retention of files after `Stop`

### DIFF
--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -234,6 +234,12 @@ func TestRunServer(t *testing.T) {
 				)
 			},
 		},
+		{
+			name: "No File Cleanup",
+			instantiation: func(t *testing.T) (*sql.DB, func()) {
+				return testserver.NewDBForTest(t, testserver.NoFileCleanup())
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			db, stop := tc.instantiation(t)


### PR DESCRIPTION
Retaining files after `Stop` can help debug some test-failures because
 one can start the server back up (off the store-dir left behind after
 failure). Looking at the data the failing test left behind can help
 hypothesize better.