### PR TITLE
Switch to docs page to determine latest stable version

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -306,9 +306,10 @@ func NonStableDbOpt() TestServerOpt {
 
 // CustomVersionOpt is a TestServer option that can be passed to NewTestServer to
 // download the a specific version of CRDB.
-func CustomVersionOpt(version string) TestServerOpt {
+func CustomVersionOpt(ver string) TestServerOpt {
 	return func(args *testServerArgs) {
-		args.customVersion = version
+		_ = version.MustParse(ver)
+		args.customVersion = ver
 	}
 }
 

--- a/testserver/testserver_test.go
+++ b/testserver/testserver_test.go
@@ -131,7 +131,7 @@ func TestRunServer(t *testing.T) {
 		{
 			name: "InsecureCustomVersion",
 			instantiation: func(t *testing.T) (*sql.DB, func()) {
-				return testserver.NewDBForTest(t, testserver.CustomVersionOpt("21.2.15"))
+				return testserver.NewDBForTest(t, testserver.CustomVersionOpt("v21.2.15"))
 			},
 		},
 		{


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach-go/issues/174

The code was previously looking at the /api/updates endpoint on the register.cockroachdb.com server. However, that endpoint returns Cloud Only releases, which cannot be downloaded from binaries.cockroachdb.com.

Now we use the releases list maintained by the docs team, which lets us filter out undesired releases.