### PR TITLE
testserver: fix URL file polling code

### DIFF
--- a/testserver/testservernode.go
+++ b/testserver/testservernode.go
@@ -148,13 +148,12 @@ func (ts *testServerImpl) StartNode(i int) error {
 	capturedI := i
 
 	if ts.pgURL[capturedI].u == nil {
-		go func() {
-			if err := ts.pollListeningURLFile(capturedI); err != nil {
-				log.Printf("%s failed to poll listening URL file: %v", testserverMessagePrefix, err)
-				close(ts.pgURL[capturedI].set)
-				ts.Stop()
-			}
-		}()
+		if err := ts.pollListeningURLFile(capturedI); err != nil {
+			log.Printf("%s failed to poll listening URL file: %v", testserverMessagePrefix, err)
+			close(ts.pgURL[capturedI].set)
+			ts.Stop()
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The asynchronous code that polls for the URL file leads to very opaque failures. This change reworks this code to waiting synchronously, so that we know the server is started before we return. In cases of failure, we now get more useful errors.