### PR TITLE
testserver: change `firstTenantID` to 3 due to UA migration

### DIFF
--- a/testserver/testserver.go
+++ b/testserver/testserver.go
@@ -70,9 +70,9 @@ const (
 )
 
 const (
-	// First tenant ID to use is 2 since 1 belongs to the system tenant. Refer
+	// First tenant ID to use is 3 since 1 belongs to the system tenant and 2 will be used for UA migration. Refer
 	// to NewTenantServer for more information.
-	firstTenantID = 2
+	firstTenantID = 3
 )
 
 // By default, we allocate 20% of available memory to the test server.


### PR DESCRIPTION
Following the migration to UA, we are not allowing tenantID 2 to be used as an application tenant anymore. Currently testserver creates tenantid 2, but it will fail to do so in the future following the rule to disable tenant id 2 in
https://github.com/cockroachdb/cockroach/pull/148561.

This change will allow us to start assigning tenantIDs from 3 and pass the failing tests in #148561.

Informs: https://github.com/cockroachdb/cockroach/issues/138801